### PR TITLE
Extract function to perform a job only

### DIFF
--- a/src/Worker.php
+++ b/src/Worker.php
@@ -259,7 +259,9 @@ class Worker implements LoggerAwareInterface
             if ($this->options['pre_perform']) {
                 $this->options['pre_perform']();
             }
-            $job->perform();
+
+            $this->performJob($job);
+
             if ($this->options['post_perform']) {
                 $this->options['post_perform']();
             }
@@ -770,6 +772,11 @@ class Worker implements LoggerAwareInterface
 
         $this->getResque()->getStatistic('failed')->incr();
         $this->getStatistic('failed')->incr();
+    }
+
+    protected function performJob(JobInterface $job): void
+    {
+        $job->perform();
     }
 
     /**


### PR DESCRIPTION
This would allow easier extension of the class (for service-based job execution), without having to copy over all the internals from `perform`