### PR TITLE
Replace strftime with date function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Forked version to add namespacing
 
+### 5.0.1 ##
+* Replace `strftime()` with `date()` to avoid deprecation warnings
+
 ### 5.0.0 ##
 * Add Docker- and Makefile to run the application
 * Add return types for functions to avoid warnings in PHP 8.1

--- a/src/Failure/RedisBackend.php
+++ b/src/Failure/RedisBackend.php
@@ -28,7 +28,7 @@ class RedisBackend implements BackendInterface
     public function receiveFailure(array $payload, Exception $exception, Worker $worker, string $queue): void
     {
         $data            = new stdClass();
-        $data->failed_at = strftime('%a %b %d %H:%M:%S %Z %Y');
+        $data->failed_at = date("D M d H:i:s T Y", time());
         $data->payload   = $payload;
         $data->exception = $this->getClass($exception);
         $data->error     = $this->getErrorMessage($this->getDistalCause($exception));

--- a/src/Worker.php
+++ b/src/Worker.php
@@ -216,7 +216,7 @@ class Worker implements LoggerAwareInterface
 
             if (!$this->child) {
                 // Forked and we're the child. Run the job.
-                $status = 'Processing ' . $job->getQueue() . ' since ' . strftime('%F %T');
+                $status = 'Processing ' . $job->getQueue() . ' since ' . date("Y-m-d H:i:s", time());;
                 $this->updateProcLine($status);
                 $this->logger->notice($status);
                 $this->perform($job);
@@ -226,7 +226,7 @@ class Worker implements LoggerAwareInterface
                 }
             } elseif ($this->child > 0) {
                 // Parent process, sit and wait
-                $status = 'Forked ' . $this->child . ' at ' . strftime('%F %T');
+                $status = 'Forked ' . $this->child . ' at ' . date("Y-m-d H:i:s", time());;
                 $this->updateProcLine($status);
                 $this->logger->info($status);
 
@@ -492,7 +492,7 @@ class Worker implements LoggerAwareInterface
     {
         $this->logger->debug('Registering worker ' . $this->getId());
         $this->resque->getClient()->sadd($this->resque->getKey(Resque::WORKERS_KEY), $this->getId());
-        $this->resque->getClient()->set($this->getJobKey() . ':started', strftime('%a %b %d %H:%M:%S %Z %Y'));
+        $this->resque->getClient()->set($this->getJobKey() . ':started', date("D M d H:i:s T Y", time()));
     }
 
     /**
@@ -533,7 +533,7 @@ class Worker implements LoggerAwareInterface
         $data = json_encode(
             [
                 'queue'   => $job->getQueue(),
-                'run_at'  => strftime('%a %b %d %H:%M:%S %Z %Y'),
+                'run_at'  => date("D M d H:i:s T Y", time()),
                 'payload' => $job->getPayload(),
             ]
         );


### PR DESCRIPTION
We need to replace the `strftime()` with the `date()` function to avoid deprecation warnings.

You can check if the output is correct by testing these:
```
echo date("Y-m-d H:i:s", time());
echo strftime("%F %T");
```
[PHP Online Eval](https://3v4l.org/1FTm8)

```
echo date("D M d H:i:s T Y", time());
echo strftime('%a %b %d %H:%M:%S %Z %Y');
```
[PHP Online Eval](https://3v4l.org/Iu9vR)